### PR TITLE
Fix: Grist update no longer removes previous user data

### DIFF
--- a/ct/grist.sh
+++ b/ct/grist.sh
@@ -50,10 +50,20 @@ function update_script() {
     cp grist_bak/landing.db grist/landing.db || true
 
     cd grist
+    msg_info "Installing Dependencies"
     yarn install >/dev/null 2>&1
+    msg_ok "Installed Dependencies"
+
+    msg_info "Building"
     yarn run build:prod >/dev/null 2>&1
+    msg_ok "Done building"
+
+    msg_info "Installing Python"
     yarn run install:python >/dev/null 2>&1
+    msg_ok "Installed Python"
+
     echo "${RELEASE}" >/opt/${APP}_version.txt
+
     msg_ok "Updated ${APP} to v${RELEASE}"
 
     msg_info "Starting ${APP} Service"

--- a/ct/grist.sh
+++ b/ct/grist.sh
@@ -34,13 +34,21 @@ function update_script() {
     msg_ok "Stopped ${APP} Service"
 
     msg_info "Updating ${APP} to v${RELEASE}"
+
     cd /opt
     rm -rf grist_bak
     mv grist grist_bak
     wget -q https://github.com/gristlabs/grist-core/archive/refs/tags/v${RELEASE}.zip
     unzip -q v$RELEASE.zip
     mv grist-core-${RELEASE} grist
-    cp -n /opt/grist_bak/.env /opt/grist/.env
+
+    mkdir -p grist/docs
+
+    cp -n grist_bak/.env grist/.env || true
+    cp -r grist_bak/docs/* grist/docs/ || true
+    cp grist_bak/grist-sessions.db grist/grist-sessions.db || true
+    cp grist_bak/landing.db grist/landing.db || true
+
     cd grist
     yarn install >/dev/null 2>&1
     yarn run build:prod >/dev/null 2>&1


### PR DESCRIPTION
## ✍️ Description  
Fixed the update script to copy known grist user files from the `/opt/grist_bak` directory to the newly installed `/opt/grist` directory.

Known user files:
- `docs/` folder, which contains `*.grist` files
- `grist-sessions.db`
- `landing.db`


## 🔗 Related PR / Discussion / Issue  
Issue: #2421
PR that introduced Grist community script: #1076



## ✅ Prerequisites  
Before this PR can be reviewed, the following must be completed:  
- [x] **Self-review performed** – Code follows established patterns and conventions.  
- [x] **Testing performed** – Changes have been thoroughly tested and verified.  


## 🛠️ Type of Change  
Select all that apply:  
- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  


## 📋 Additional Information (optional)  

